### PR TITLE
使用外部程序 fping 代替 ping3 进行延时测试与 shebang 问题修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ pip3 install -r requirement.txt
 
 ```
 
+需要 fping 来进行 ping 测试，如果您不需要可不安装，如果需要，请根据您的操作系统发行版进行安装。  
+对于 Debian 系发行版：
+```shell
+apt install fping
+```
+
 ## 使用方法
 
 ```

--- a/autoStart.sh
+++ b/autoStart.sh
@@ -1,10 +1,10 @@
+#!/bin/bash
 ##########################################################################
 # File Name: autoStart.sh
 # Author: TyrantLucifer
 # mail: TyrantLucifer@linuxstudy.cn
 # Created Time: Wed 03 Jun 2020 09:49:37 PM CST
 ##########################################################################
-#!/bin/bash
 
 # 初始化环境变量
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:~/bin

--- a/main.sh
+++ b/main.sh
@@ -66,7 +66,7 @@ change_ssr_node(){
 
 update_ssr_list(){
     clear
-    sudo python3 main.py -u
+    python3 main.py -u
     clear
     list_ssr
 }

--- a/main.sh
+++ b/main.sh
@@ -1,10 +1,10 @@
+#!/bin/bash
 ##########################################################################
 # File Name: main.sh
 # Author: TyrantLucifer
 # mail: TyrantLucifer@linuxstudy.cn
 # Created Time: Wed 03 Jun 2020 10:17:52 PM CST
 ##########################################################################
-#!/bin/bash
 
 # 初始化环境变量
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:~/bin

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,5 +1,4 @@
 requests
-ping3
 colorama
 shadowsocks
 prettytable

--- a/utils.py
+++ b/utils.py
@@ -174,7 +174,7 @@ def generate_ssr_display_table(ssr_info_dict_list):
 def get_ping_speed(server, remarks):
     color = colored()
     try:
-        ping_result = subprocess.run(['/usr/bin/fping', '-Dae', server], capture_output=True).stdout.decode().strip()
+        ping_result = subprocess.run(['/usr/bin/fping', '-Dae4', server], capture_output=True).stdout.decode().strip()
         ping_speed = float(re.findall(r'\((.*)\ ms\)$', ping_result)[0])
     except:
         ping_speed = None

--- a/utils.py
+++ b/utils.py
@@ -7,7 +7,7 @@ import base64
 import zipfile
 import configparser
 import socket
-import ping3
+import subprocess
 import re
 import os
 from prettytable import PrettyTable
@@ -173,7 +173,11 @@ def generate_ssr_display_table(ssr_info_dict_list):
 # 获取ssr节点ping值
 def get_ping_speed(server, remarks):
     color = colored()
-    ping_speed = ping3.ping(server, timeout=5, unit='ms')
+    try:
+        ping_result = subprocess.run(['/usr/bin/fping', '-Dae', server], capture_output=True).stdout.decode().strip()
+        ping_speed = float(re.findall(r'\((.*)\ ms\)$', ping_result)[0])
+    except:
+        ping_speed = None
     if ping_speed:
         flag = color.green('√')
         ping_speed = format(ping_speed, '.3f')


### PR DESCRIPTION
ping3 作为一个 Python 库，其运行权限取决于 Python 主程序运行的权限。  
要使用 ping3 进行延时测试，则必须对该脚本使用 root 权限执行或对 Python 主程序进行 setcap，这两种方式都不理想。尽管脚本主要开发目的是一键化管理，但同样不可忽视的是部分用户（比如我）希望它只做好管理订阅的工作，这时低权限执行就是一种更加理想的执行方式。

如果使用 fping 代替 ping3 进行延时测试，因为 fping 本身带有 setuid 标志位，脚本可以以较低的权限执行，从而避免一些安全问题并且可以缩小意外情况脚本出现问题造成的影响。   

另外，`main.sh` 的 shebang 位置有误，在这个 Pull Request 中一并予以修复。
`autoStart.sh` 的 shebang 与权限问题也一并修复。