### PR TITLE
fix: server should startup when no protocol_param provided

### DIFF
--- a/shadowsocksr_cli/parse_utils.py
+++ b/shadowsocksr_cli/parse_utils.py
@@ -95,6 +95,7 @@ class ParseShadowsocksr(object):
                 ssr_dict['fast_open'] = False
                 ssr_dict['verbose'] = False
                 ssr_dict['connect_verbose_info'] = 0
+                ssr_dict.setdefault("protocol_param", 0)
                 return ssr_dict
             else:
                 logger.debug("Currently it is not support ipv6 node")


### PR DESCRIPTION
ssr订阅或地址中未设置protocol_param时, 服务器报错, 启动失败. (包括readme中提供的测试节点)
> 2021-11-03 10:36:52,311 - handle_utils.py[line:127] - [operate_on_unix] - ERROR: 'protocol_param'

修改: 提供了一个默认值后可以正常启动.