### PR TITLE
fix issue33: list index out of range if there is no data after '/?'

### DIFF
--- a/shadowsocksr_cli/parse_utils.py
+++ b/shadowsocksr_cli/parse_utils.py
@@ -64,27 +64,30 @@ class ParseShadowsocksr(object):
                 obfs = param_list[4]
                 first_encryption_param_list = param_list[5].split('/?')
                 password = ParseShadowsocksr.base64_decode(first_encryption_param_list[0])
-                second_encryption_param_list = first_encryption_param_list[-1].split('&')
+
                 key_list = [
                     'obfs_param',
                     'protocol_param',
                     'remarks',
                     'group'
                 ]
-                for params in second_encryption_param_list:
-                    key = params.split('=')[0]
-                    value = params.split('=')[1]
-                    if key == 'obfsparam':
-                        key = 'obfs_param'
-                    if key == 'protoparam':
-                        key = 'protocol_param'
-                    if key in key_list:
-                        try:
-                            ssr_dict[key] = ParseShadowsocksr.base64_decode(value)
-                        except Exception as e:
-                            logger.error(e)
-                            logger.warning("base64 decode {0} error, it will use raw value {1}".format(key, value))
-                            ssr_dict[key] = value
+                if len(first_encryption_param_list) > 1:
+                    second_encryption_param_list = first_encryption_param_list[-1].split('&')
+                    for params in second_encryption_param_list:
+                        key = params.split('=')[0]
+                        value = params.split('=')[1]
+                        if key == 'obfsparam':
+                            key = 'obfs_param'
+                        if key == 'protoparam':
+                            key = 'protocol_param'
+                        if key in key_list:
+                            try:
+                                ssr_dict[key] = ParseShadowsocksr.base64_decode(value)
+                            except Exception as e:
+                                logger.error(e)
+                                logger.warning("base64 decode {0} error, it will use raw value {1}".format(key, value))
+                                ssr_dict[key] = value
+
                 ssr_dict['server'] = server
                 ssr_dict['server_port'] = int(port)
                 ssr_dict['method'] = method


### PR DESCRIPTION
修复 https://github.com/TyrantLucifer/ssr-command-client/issues/33  

修复前，例如：
```sh
shadowsocksr-cli --add-ssr ssr://MTIzLjEyMy4xMjMuMTIzOjEyMzQ1OmF1dGhfYWVzMTI4X3NoYTE6YWVzLTI1Ni1jZmI6cGxhaW46YW1zNGNrVm5ZMjF6TlV4WVRrNVlhRUZD
# 123.123.123.123:12345:auth_aes128_sha1:aes-256-cfb:plain:ams4ckVnY21zNUxYTk5YaEFC

Traceback (most recent call last):
  File "/home/username/.local/bin/shadowsocksr-cli", line 8, in <module>
    sys.exit(main())
  File "/home/username/.local/lib/python3.10/site-packages/shadowsocksr_cli/main.py", line 84, in main
    UpdateConfigurations.add_shadowsocksr_by_url(args.add_ssr)
  File "/home/username/.local/lib/python3.10/site-packages/shadowsocksr_cli/functions.py", line 125, in add_shadowsocksr_by_url
    update_shadowsocksr.add_shadowsocksr_by_url(ssr_url)
  File "/home/username/.local/lib/python3.10/site-packages/shadowsocksr_cli/update_utils.py", line 53, in add_shadowsocksr_by_url
    ssr_dict = ParseShadowsocksr.parse_shadowsocksr(ssr_url)
  File "/home/username/.local/lib/python3.10/site-packages/shadowsocksr_cli/parse_utils.py", line 76, in parse_shadowsocksr
    value = params.split('=')[1]
IndexError: list index out of range
```


修复后，可以正常添加 ssr 链接