### PR TITLE
add http-proxy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ alias setproxy="export ALL_PROXY=socks5://127.0.0.1:1080"
 alias unsetproxy="unset ALL_PROXY"
 alias ip="curl http://ip-api.com/json/?lang=zh-CN"
 ```
+- if you prefer socks5 to http proxy, you can use this command `shadowsocksr-cli -p 1080 --http-proxy start --http-proxy-port 7890`
+- then you can add the following content in you `~/.bashrc`
+```shell
+alias setproxy="export ALL_PROXY=http://127.0.0.1:7890"
+alias unsetproxy="unset ALL_PROXY"
+alias ip="curl http://ip-api.com/json/?lang=zh-CN"
+```
+
 ## Support open source:heart:, Buy the author a Starbucks
 
 > If you are willing to donate, please write your Github account in the donation note. Thank you  

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The command client of shadowsocksr based by python
 - Support generate json and qrcode for shadowsocksr node
 - Support generate clash config file for your shadowsocksr subscribe
 - Support open http pac proxy
+- Support convert socks proxy to http proxy
 - Not Support ipv6 shadowsocksr node
 - Developed by pure python
 

--- a/README.md
+++ b/README.md
@@ -177,9 +177,8 @@ alias ip="curl http://ip-api.com/json/?lang=zh-CN"
 - if you prefer socks5 to http proxy, you can use this command `shadowsocksr-cli -p 1080 --http-proxy start --http-proxy-port 7890`
 - then you can add the following content in you `~/.bashrc`
 ```shell
-alias setproxy="export ALL_PROXY=http://127.0.0.1:7890"
-alias unsetproxy="unset ALL_PROXY"
-alias ip="curl http://ip-api.com/json/?lang=zh-CN"
+alias sethttpsproxy="export HTTPS_PROXY=http://127.0.0.1:7890"
+alias unsethttpsproxy="unset HTTPS_PROXY"
 ```
 
 ## Support open source:heart:, Buy the author a Starbucks

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ optional arguments:
                         Manager local http server
   --http-port http server port
                         assign local http server port
+  --http-proxy action[start stop status]
+                        Convert socks5 proxy to http proxy
+  --http-proxy-port http proxy port
+                        assign local http proxy port
   --setting-global-proxy
                         setting system global proxy,only support on   
                         Ubuntu Desktop

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ Features
 - Support test shadowsocksr download and upload speed
 - Support print shadowsocksr information by qrcode or json format
 - Support generate clash fundamental config file
+- Support convert socks proxy to http proxy
 
 How to install
 --------------

--- a/README_CH.md
+++ b/README_CH.md
@@ -19,6 +19,7 @@
 - 整合Shadowsocksr源码到项目中
 - 支持生成基础版clash配置文件
 - 支持开启本地http pac代理服务
+- 支持socks5代理转http代理
 - 暂时不支持`ipv6`Shadowsocksr节点，解析时会默认屏蔽
 
 ## 安装方式

--- a/README_CH.md
+++ b/README_CH.md
@@ -184,6 +184,13 @@ setproxy 开启代理
 unsetproxy 关闭代理
 ip 查看ip归属地
 ```
+- 如果你需要使用http代理而不是socks代理，使用这个命令可以将socks5代理转换为http代理 `shadowsocksr-cli -p 1080 --http-proxy start --http-proxy-port 7890`
+- 然后你就可以将以下快捷命令添加到 `~/.bashrc`
+```shell
+alias sethttpsproxy="export HTTPS_PROXY=http://127.0.0.1:7890"
+alias unsethttpsproxy="unset HTTPS_PROXY"
+```
+
 
 ## 常见问题
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -108,6 +108,9 @@ optional arguments:
 
 --http-port PORT 指定本地http服务器端口号，默认为80
 
+--http-proxy action[start stop status] 将socks5代理转换为http代理
+                        
+--http-proxy-port 指定http代理的服务端口
 ```
 
 ## 简单示例

--- a/shadowsocksr_cli/common.py
+++ b/shadowsocksr_cli/common.py
@@ -28,3 +28,9 @@ http_local_server = HTTPLocalServer("HTTPLocalServer",
                                     init_config.http_server_pid_file,
                                     stderr=init_config.http_error_log_file,
                                     verbose=1)
+
+# 初始化工具类http_utils.HTTPProxyServer
+http_proxy_server = HTTPProxyServer("HTTPProxyServer", 
+                                    init_config.http_proxy_server_pid_file,
+                                    stderr=init_config.http_proxy_error_log_file,
+                                    verbose=1)

--- a/shadowsocksr_cli/functions.py
+++ b/shadowsocksr_cli/functions.py
@@ -434,3 +434,44 @@ class HandleHttpServer(object):
                 logger.info("HTTP Server status:{0}".format(http_local_server.is_running()))
         else:
             logger.error("--http not support this option: {0}".format(action))
+
+
+class HandleHttpProxy(object):
+    """
+    将socks5代理转换为http代理
+    """
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def start(socks_port, http_proxy_port):
+        if init_config.platform == 'win32':
+            http_proxy_server.start_on_windows(socks_port=socks_port,
+                                               http_proxy_port=http_proxy_port)
+        else:
+            http_proxy_server.start(init_config.http_log_file,
+                                    socks_port=socks_port,
+                                    http_proxy_port=http_proxy_port)
+
+    @staticmethod
+    def stop():
+        http_proxy_server.stop()
+
+    @staticmethod
+    def handle_http_proxy(action, socks_port, http_proxy_port):
+        if action == "start":
+            HandleHttpProxy.start(socks_port=socks_port, http_proxy_port=http_proxy_port)
+        elif action == "stop":
+            if init_config.platform == "win32":
+                logger.error("Only support unix platform")
+            else:
+                HandleHttpProxy.stop()
+        elif action == "status":
+            if init_config.platform == "win32":
+                logger.error("Only support unix platform")
+            else:
+                logger.info("HTTP Server status:{0}".format(http_proxy_server.is_running()))
+        else:
+            logger.error("--http-proxy not support this option: {0}".format(action))
+

--- a/shadowsocksr_cli/init_utils.py
+++ b/shadowsocksr_cli/init_utils.py
@@ -70,7 +70,7 @@ class InitConfig(object):
                                           'httpd.log')
         self.http_error_log_file = os.path.join(self.config_dir,
                                                 'httpd_error.log')
-        self.http_proxy_server_pid_file = os.join(self.config_dir,
+        self.http_proxy_server_pid_file = os.path.join(self.config_dir,
                                                   'httpproxy.pid')
         self.http_proxy_error_log_file = os.path.join(self.config_dir,
                                                 'httpproxy.log')

--- a/shadowsocksr_cli/init_utils.py
+++ b/shadowsocksr_cli/init_utils.py
@@ -70,6 +70,10 @@ class InitConfig(object):
                                           'httpd.log')
         self.http_error_log_file = os.path.join(self.config_dir,
                                                 'httpd_error.log')
+        self.http_proxy_server_pid_file = os.join(self.config_dir,
+                                                  'httpproxy.pid')
+        self.http_proxy_error_log_file = os.path.join(self.config_dir,
+                                                'httpproxy.log')
         self.subscribe_url = 'https://tyrantlucifer.com/ssr/ssr.txt'
         self.local_address = '127.0.0.1'
         self.timeout = 300

--- a/shadowsocksr_cli/main.py
+++ b/shadowsocksr_cli/main.py
@@ -42,6 +42,9 @@ def get_parser():
     parser.add_argument("--http", metavar="action[start stop status]", help="Manager local http server")
     parser.add_argument("--http-port", metavar="http server port", default=10000, type=int,
                         help="assign local http server port")
+    parser.add_argument("--http-proxy", metavar="action[start stop status]", help="Convert socks5 proxy to http proxy")
+    parser.add_argument("--http-proxy-port", metavar="http proxy port", default=7890, type=int,
+                        help="assign local http proxy port")
     parser.add_argument("--setting-global-proxy", action="store_true",
                         help="setting system global proxy,only support on " + color.red('Ubuntu Desktop'))
     parser.add_argument("--setting-pac-proxy", action="store_true",
@@ -104,6 +107,8 @@ def main():
         GenerateClashConfig.generate_clash_config()
     elif args.http:
         HandleHttpServer.handle_http_server(args.http, args.port, args.http_port)
+    elif args.http_proxy:
+        HandleHttpProxy.handle_http_proxy(args.http_proxy, args.port, args.http_proxy_port)
     else:
         parser.print_help()
 

--- a/shadowsocksr_cli/proxy_socks2http.py
+++ b/shadowsocksr_cli/proxy_socks2http.py
@@ -1,3 +1,7 @@
+"""
+Adapted from [Xiangsong Zeng](https://gist.github.com/zengxs)
+Reference gist: proxy_socks2http.py https://gist.github.com/zengxs/dc6cb4dea4495ecaab7b44abb07a581f
+"""
 import asyncio
 import logging
 import re

--- a/shadowsocksr_cli/proxy_socks2http.py
+++ b/shadowsocksr_cli/proxy_socks2http.py
@@ -1,0 +1,148 @@
+import asyncio
+import logging
+import re
+from asyncio import StreamReader, StreamReaderProtocol, StreamWriter
+from collections import namedtuple
+from typing import Optional
+
+import socks  # use pysocks
+
+logging.basicConfig(level=logging.INFO)
+
+HttpHeader = namedtuple(
+    "HttpHeader", ["method", "url", "version", "connect_to", "is_connect"]
+)
+
+
+async def dial(client_conn, server_conn):
+    async def io_copy(reader: StreamReader, writer: StreamWriter):
+        while True:
+            data = await reader.read(8192)
+            if not data:
+                break
+            writer.write(data)
+        writer.close()
+
+    asyncio.ensure_future(io_copy(client_conn[0], server_conn[1]))
+    asyncio.ensure_future(io_copy(server_conn[0], client_conn[1]))
+
+
+async def open_socks5_connection(
+    host: str,
+    port: int,
+    *,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    socks_host: str = "localhost",
+    socks_port: int = 1080,
+    limit=2**16,
+    loop=None
+):
+    s = socks.socksocket()
+    s.set_proxy(
+        socks.SOCKS5,
+        addr=socks_host,
+        port=socks_port,
+        username=username,
+        password=password,
+    )
+    s.connect((host, port))
+
+    if not loop:
+        loop = asyncio.get_event_loop()
+
+    reader = StreamReader(limit=limit, loop=loop)
+    protocol = StreamReaderProtocol(reader, loop=loop)
+    transport, _ = await loop.create_connection(lambda: protocol, sock=s)
+    writer = StreamWriter(transport, protocol, reader, loop)
+    return reader, writer
+
+
+async def read_until_end_of_http_header(reader: StreamReader) -> bytes:
+    lines = []
+    while True:
+        line = await reader.readline()
+        lines.append(line)
+        if line == b"\r\n":
+            break
+
+    return b"".join(lines)
+
+
+def parse_http_header(header: bytes) -> HttpHeader:
+    lines = header.split(b"\r\n")
+    fl = lines[0].decode()
+    method, url, version = fl.split(" ", 2)
+
+    if method.upper() == "CONNECT":
+        host, port = url.split(":", 1)
+        port = int(port)
+    else:
+        # find Host header line
+        host_text = None
+        for header_line in lines:
+            hl = header_line.decode()
+            if re.match(r"^host:", hl, re.IGNORECASE):
+                host_text = re.sub(r"^host:\s*", "", hl, count=1, flags=re.IGNORECASE)
+                break
+
+        if not host_text:
+            raise ValueError("No http host line")
+
+        if ":" not in host_text:
+            host = host_text
+            port = 80
+        else:
+            host, port = host_text.split(":", 1)
+            port = int(port)
+
+    is_connect = method.upper() == "CONNECT"
+    return HttpHeader(
+        method=method,
+        url=url,
+        version=version,
+        connect_to=(host, port),
+        is_connect=is_connect,
+    )
+
+
+async def handle_connection(reader: StreamReader, writer: StreamWriter, socks_port=1080):
+    try:
+        http_header_bytes = await read_until_end_of_http_header(reader)
+        http_header = parse_http_header(http_header_bytes)
+    except (IOError, ValueError) as e:
+        logging.error(e)
+        writer.close()
+        return
+
+    server_conn = await open_socks5_connection(
+        host=http_header.connect_to[0],
+        port=http_header.connect_to[1],
+        socks_host="localhost",
+        socks_port=socks_port,
+    )
+
+    if http_header.is_connect:
+        writer.write(b"HTTP/1.0 200 Connection Established\r\n\r\n")
+    else:
+        server_writer = server_conn[1]
+        server_writer.write(http_header_bytes)
+
+    # 建立双向连接
+    asyncio.ensure_future(dial((reader, writer), server_conn))
+
+
+def main():
+    loop = asyncio.get_event_loop()
+    server = asyncio.start_server(handle_connection, host="localhost", port=7890)
+    try:
+        server = loop.run_until_complete(server)
+        loop.run_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add command to convert socks proxy to http proxy.
Related to #93 #92 #86 #74

First start socks5 proxy
```bash
shadowsocksr-cli -s 1 -p 1080
```

start http server on 7890 to proxy socks5 on 1080
```bash
shadowsocksr-cli -p 1080 --http-proxy start --http-proxy-port 7890
```

check http proxy status
```bash
shadowsocksr-cli --http-proxy status
```

stop http proxy
```bash
shadowsocksr-cli --http-proxy stop
```

Usage
```bash
export ALL_PROXY="http://localhost:7890"
```

Reference gist: [proxy_socks2http.py](https://gist.github.com/zengxs/dc6cb4dea4495ecaab7b44abb07a581f)
